### PR TITLE
docs: update standalone keycloak theme section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ mv src/KcApp/* src/
 
 cat << EOF > src/index.tsx
 import { createRoot } from "react-dom/client";
-import { StrictMode, lazy, Suspense } from "react";
-import { kcContext } from "./KcApp/kcContext";
+import { StrictMode, lazy } from "react";
+import { kcContext } from "./kcContext";
 
 const KcApp = lazy(() => import("./KcApp"));
 


### PR DESCRIPTION
The section **Standalone keycloak theme** in the `README.md` has two minor bugs in the import statements.